### PR TITLE
Add helper script for auto-restarting app

### DIFF
--- a/run_app.sh
+++ b/run_app.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Simple script to run the NWNX:EE Chatbot app and automatically restart
+# if it stops. Useful for basic development or testing environments.
+
+# Always run from the script's directory
+cd "$(dirname "$0")" || exit 1
+
+# Install dependencies if required
+if ! python3 -c "import eventlet" >/dev/null 2>&1; then
+  echo "Installing Python dependencies..."
+  python3 -m pip install -q -r requirements.txt
+fi
+
+while true; do
+  echo "Starting app..."
+  python3 app.py
+  exit_code=$?
+  echo "App exited with status $exit_code. Restarting in 5 seconds..."
+  sleep 5
+done


### PR DESCRIPTION
## Summary
- add a small bash script `run_app.sh` to start `app.py` and restart it if it exits
- install requirements if `eventlet` is missing

## Testing
- `python -m py_compile app.py character_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68434068bf808326b3815dcb941158c4