### PR TITLE
Add helper script for auto-restarting app

### DIFF
--- a/run_app.sh
+++ b/run_app.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Simple script to run the NWNX:EE Chatbot app and automatically restart if it
+# stops. Creates a local virtual environment if dependencies are missing.
+
+set -e
+cd "$(dirname "$0")" || exit 1
+
+PYTHON="python3"
+
+if ! python3 -c "import eventlet" >/dev/null 2>&1; then
+  echo "Setting up virtual environment and installing dependencies..."
+  if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+  fi
+  PYTHON=".venv/bin/python"
+  "$PYTHON" -m pip install -q -r requirements.txt
+else
+  echo "Dependencies already installed."
+fi
+
+while true; do
+  echo "Starting app..."
+  "$PYTHON" app.py
+  exit_code=$?
+  echo "App exited with status $exit_code. Restarting in 5 seconds..."
+  sleep 5
+done


### PR DESCRIPTION
## Summary
- add a small bash script `run_app.sh` to start `app.py` and restart it if it exits
- install requirements if `eventlet` is missing
- use a local virtual environment when dependencies are missing

## Testing
- `python -m py_compile app.py character_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68434068bf808326b3815dcb941158c4